### PR TITLE
Update the action and inherit ansible-lint arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,6 @@ inputs:
       Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
       or directories containing any of the specified.
       NOTE: The directory traversal is not recursive
-    default: '.'
     required: true
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,44 @@
+name: 'Ansible Lint'
+description: 'Run Ansible Lint'
+author: 'Ansible by Red Hat <info@ansible.com>'
+
+inputs: 
+  args:
+    description: |
+      Arguments to be passed to the ansible-lint
+
+      Options:
+        -q                    quieter, although not silent output
+        -p                    parseable output in the format of pep8
+        --parseable-severity  parseable output including severity of rule
+        -r RULESDIR           specify one or more rules directories using one or
+                              more -r arguments. Any -r flags override the default
+                              rules in ansiblelint/rules, unless -R is also used.
+        -R                    Use default rules in ansiblelint/rules in addition to
+                              any extra
+                              rules directories specified with -r. There is no need
+                              to specify this if no -r flags are used
+        -t TAGS               only check rules whose id/tags match these values
+        -x SKIP_LIST          only check rules whose id/tags do not match these
+                              values
+        --nocolor             disable colored output
+        --exclude=EXCLUDE_PATHS
+                              path to directories or files to skip. This option is
+                              repeatable.
+        -c C                  Specify configuration file to use. Defaults to ".ansible-lint"
+
+    required: false
+  targets:
+    description: |
+      Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
+      or directories containing any of the specified.
+      NOTE: The directory traversal is not recursive
+    default: '.'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - '${{ inputs.args }}'
+  env:
+    TARGETS: '${{ inputs.targets }}'

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ inputs:
   targets:
     description: |
       Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
-      or directories containing any of the specified.
-      NOTE: The directory traversal is not recursive
+      or valid Ansible directories according to the Ansible role
+      directory structure.
     required: true
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,10 +77,11 @@ parse_args() {
 # env:
 #   [required] TARGETS : Files or directories (i.e., playbooks, tasks, handlers etc..) to be linted
 ansible::lint() {
-  : "${TARGETS?No TARGETS to check. Nothing to do.}"
+  : "${TARGETS?No targets to check. Nothing to do.}"
+  : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
+  pushd ${GITHUB_WORKSPACE}
 
   local opts=$(parse_args "$@" || exit 1)
-
   if [ "$opts" = "" ]; then
     ansible-lint -v --force-color ${TARGETS}
   else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,30 +1,97 @@
 #! /usr/bin/env bash
 
-set -eo pipefail
+set -euo pipefail
 set -x
 
-ACTION_PLAYBOOK_NAME="${ACTION_PLAYBOOK_NAME:-playbook.yml}"
+# Filter out arguments that are not available to this action
+# args:
+#   $@: Arguments to be filtered
+parse_args() {
+  local opts=""
+  while (( "$#" )); do
+    case "$1" in
+      -q|--quiet)
+        opts="$opts -q"
+        shift
+        ;;
+      -c)
+        opts="$opts -c $2"
+        shift 2
+        ;;
+      -p)
+        opts="$opts -p"
+        shift
+        ;;
+      -r)
+        opts="$opts -r $2"
+        shift 2
+        ;;
+      -R)
+        opts="$opts -R"
+        shift
+        ;;
+      -t)
+        opts="$opts -t $2"
+        shift 2
+        ;;
+      -x)
+        opts="$opts -x $2"
+        shift 2
+        ;;
+      --exclude)
+        opts="$opts --exclude=$2"
+        shift 2
+        ;;
+      --no-color)
+        opts="$opts --no-color"
+        shift
+        ;;
+      --parseable-severity)
+        opts="$opts --parseable-severity"
+        shift
+        ;;
+      --) # end argument parsing
+        shift
+        break
+        ;;
+      -*|--*=) # unsupported flags
+        >&2 echo "ERROR: Unsupported flag: '$1'"
+        exit 1
+        ;;
+      *) # positional arguments
+        shift  # ignore
+        ;;
+    esac
+  done
 
-set -u
+  # set remaining positional arguments (if any) in their proper place
+  eval set -- "$opts"
 
-cd "${GITHUB_WORKSPACE}"
+  echo "${opts/ /}"
+  return 0
+}
 
-ACTION_PLAYBOOK_PATH="${GITHUB_WORKSPACE}/${ACTION_PLAYBOOK_NAME}"
+# Generates client.
+# args:
+#   $@: additional options
+# env:
+#   [required] TARGETS : Files or directories (i.e., playbooks, tasks, handlers etc..) to be linted
+ansible::lint() {
+  : "${TARGETS?No TARGETS to check. Nothing to do.}"
 
-if [ ! -f "${ACTION_PLAYBOOK_PATH}" -a ! -d "${ACTION_PLAYBOOK_PATH}" ]; then
-  >&2 echo "==> Can't find '${ACTION_PLAYBOOK_PATH}'.
-    Please ensure to set up ACTION_PLAYBOOK_NAME env var
-    relative to the root of your project."
-  exit 1
+  local opts=$(parse_args "$@" || exit 1)
+
+  if [ "$opts" = "" ]; then
+    ansible-lint -v --force-color ${TARGETS}
+  else
+    ansible-lint -v --force-color $opts ${TARGETS}
+  fi
+}
+
+
+args=("$@")
+
+if [ "$0" = "$BASH_SOURCE" ] ; then
+  >&2 echo -E "\nRunning Ansible Lint...\n"
+  ansible::lint ${args[@]}
 fi
-
->&2 echo
->&2 echo "==> Linting ${ACTION_PLAYBOOK_PATH}…"
-
-if [ -d "${ACTION_PLAYBOOK_PATH}" ]; then
-  ansible-lint `find "${ACTION_PLAYBOOK_PATH}" -type f -name playbook.yml`
-else
-  ansible-lint "${ACTION_PLAYBOOK_PATH}"
-fi
-
->&2 echo

--- a/readme.md
+++ b/readme.md
@@ -3,21 +3,78 @@ This action allows you to run `ansible-lint` with no additional options.
 
 
 ## Usage
-To use the action simply add the following lines to your `.github/main.workflow`.
+To use the action simply create an `ansible-lint.yml` (or choose custom `*.yml` name) in the `.github/workflows/` directory.
 
-```hcl
-action "Lint Ansible Playbook" {
-  uses = "ansible/ansible-lint-action@master"
-}
+For example:
+
+```yaml
+name: Ansible Lint  # feel free to pick your own name
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # Important: This sets up your GITHUB_WORKSPACE environment variable
+    - uses: actions/checkout@v1
+    - name: Lint Ansible Playbook
+      # replace "master" with any valid ref
+      uses: ansible/ansible-lint-action@master
+      with:
+        # [required]
+        # Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
+        # or valid Ansible directories according to the Ansible role
+        # directory structure.
+        targets: ""
+        # [optional]
+        # Arguments to be passed to the ansible-lint
+
+        # Options:
+        #   -q                    quieter, although not silent output
+        #   -p                    parseable output in the format of pep8
+        #   --parseable-severity  parseable output including severity of rule
+        #   -r RULESDIR           specify one or more rules directories using one or
+        #                         more -r arguments. Any -r flags override the default
+        #                         rules in ansiblelint/rules, unless -R is also used.
+        #   -R                    Use default rules in ansiblelint/rules in addition to
+        #                         any extra
+        #                         rules directories specified with -r. There is no need
+        #                         to specify this if no -r flags are used
+        #   -t TAGS               only check rules whose id/tags match these values
+        #   -x SKIP_LIST          only check rules whose id/tags do not match these
+        #                         values
+        #   --nocolor             disable colored output
+        #   --exclude=EXCLUDE_PATHS
+        #                         path to directories or files to skip. This option is
+        #                         repeatable.
+        #   -c C                  Specify configuration file to use. Defaults to ".ansible-lint"
+        args: ""
+
 ```
 
-N.B. Use `v4.1.0` or any other valid tag, or branch, or commit SHA instead
-of `master` to pin the action to use a specific version.
+> TIP: N.B. Use `ansible/ansible-lint-action@v4.1.0` or any other valid tag, or branch, or commit SHA instead of `v4.1.0` to pin the action to use a specific version.
 
+Alternatively, you can run the ansible lint only on certain branches:
 
-### Environment Variables
-- **ACTION_PLAYBOOK_NAME**: (optional) defaults to `playbook.yml`
+```yaml
 
+on:
+  push:
+    branches:
+    - stable
+    - release/v*
+```
+
+or on various [events](https://help.github.com/en/articles/events-that-trigger-workflows):
+
+```yaml
+on: [push, pull_request]
+```
+
+<br>
 
 ## License
 The Dockerfile and associated scripts and documentation in this project are released under the [MIT](license).


### PR DESCRIPTION
- the action now takes a limited set of arguments and passes them to `ansible-lint` (see the [README](/action.yml)
- created action.yaml
- updated documentation

An example run can be found [here](https://github.com/CermakM/ansible-role-argo-workflows/commit/dc73d169da03e9f99c6888262dc08c18c32bff14/checks?check_suite_id=260254803).