### PR TITLE
change python-docker from 3.7-slim to 3.8-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 LABEL "maintainer"="Ansible by Red Hat <info@ansible.com>"
 LABEL "repository"="https://github.com/ansible/ansible-lint-action"


### PR DESCRIPTION
I updated the python version in the Dockerfile from 3.7-slim to 3.8-slim.

I tested it [here](https://github.com/roles-ansible/role_ranger/runs/490417621) and it works fine as far as I see.