### PR TITLE
Adding functionality to pin ansible-lint versions through input variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,5 @@ LABEL "com.github.actions.description"="Run Ansible Lint"
 LABEL "com.github.actions.icon"="activity"
 LABEL "com.github.actions.color"="gray-dark"
 
-RUN pip install ansible-lint
-
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,8 @@ LABEL "com.github.actions.description"="Run Ansible Lint"
 LABEL "com.github.actions.icon"="activity"
 LABEL "com.github.actions.color"="gray-dark"
 
+RUN pip install ansible-lint
+
 COPY entrypoint.sh /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ jobs:
         #   playbook_2.yml
         targets: ""
         # [optional]
+        # If you wish to pin the version of ansible-lint being used you can set the version explicitly
+        # Default version will be used if not set: v4.2.0
+        version: ""
+        # [optional]
         # Arguments to be passed to the ansible-lint
 
         # Options:

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ jobs:
         #   playbook_2.yml
         targets: ""
         # [optional]
-        # If you wish to pin the version of ansible-lint being used you can set the version explicitly
-        # Default version will be used if not set: v4.2.0
-        version: ""
+        # Arguments to override a package and its version to be set explicitly.
+        # Must follow the example syntax.
+        override-dep: |
+          ansible==2.10
+          ansible-lint==4.2.0
         # [optional]
         # Arguments to be passed to the ansible-lint
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ jobs:
         # [optional]
         # Arguments to override a package and its version to be set explicitly.
         # Must follow the example syntax.
-        override-dep: |
-          ansible==2.10
+        override-deps: |
+          ansible==2.9
           ansible-lint==4.2.0
         # [optional]
         # Arguments to be passed to the ansible-lint

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: Ansible Lint
 description: Run Ansible Lint
 author: Ansible by Red Hat <info@ansible.com>
 
-inputs: 
+inputs:
   args:
     description: |
       Arguments to be passed to the ansible-lint
@@ -34,10 +34,15 @@ inputs:
       or valid Ansible directories according to the Ansible role
       directory structure.
     required: true
+  version:
+    description: |
+      Version of ansible-lint that should be used. This allows to pin to a target
+      version in order to maintain consistency with local development.
+    required: false
 runs:
   using: docker
   image: Dockerfile
   args:
-  - ${{ inputs.args }}
+    - ${{ inputs.args }}
   env:
     TARGETS: ${{ inputs.targets }}

--- a/action.yml
+++ b/action.yml
@@ -46,4 +46,4 @@ runs:
   - ${{ inputs.args }}
   env:
     TARGETS: ${{ inputs.targets }}
-    VERSION: ${{ inputs.targets }}
+    VERSION: ${{ inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
   using: docker
   image: Dockerfile
   args:
-    - ${{ inputs.args }}
+  - ${{ inputs.args }}
   env:
     TARGETS: ${{ inputs.targets }}
     VERSION: ${{ inputs.targets }}

--- a/action.yml
+++ b/action.yml
@@ -46,3 +46,4 @@ runs:
     - ${{ inputs.args }}
   env:
     TARGETS: ${{ inputs.targets }}
+    VERSION: ${{ inputs.targets }}

--- a/action.yml
+++ b/action.yml
@@ -34,10 +34,10 @@ inputs:
       or valid Ansible directories according to the Ansible role
       directory structure.
     required: true
-  version:
+  override-deps:
     description: |
-      Version of ansible-lint that should be used. This allows to pin to a target
-      version in order to maintain consistency with local development.
+      override-deps allows pinning pip packages and there versions. This allows to pin to a target
+      package version in order to maintain consistency with local development.
     required: false
 runs:
   using: docker
@@ -46,4 +46,4 @@ runs:
   - ${{ inputs.args }}
   env:
     TARGETS: ${{ inputs.targets }}
-    VERSION: ${{ inputs.version }}
+    OVERRIDE: ${{ inputs.override-deps }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,7 @@ parse_args() {
 }
 
 override_python_packages() {
-  [[ -n ${OVERRIDE} ]] && pip install "${OVERRIDE}"
+  [[ -n ${OVERRIDE} ]] && pip install "${OVERRIDE}" && pip check
 }
 
 # Generates client.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,5 +91,5 @@ args=("$@")
 
 if [ "$0" = "$BASH_SOURCE" ] ; then
   >&2 echo -E "\nRunning Ansible Lint...\n"
-  ansible::lint ${args[@]}
+  ansible::lint "${args[@]}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,7 +81,8 @@ ansible::lint() {
   : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
   pushd "${GITHUB_WORKSPACE}"
 
-  local opts=$(parse_args "$@" || exit 1)
+  local opts
+  opts=$(parse_args "$@" || exit 1)
 
   ansible-lint -v --force-color "$opts" "${TARGETS}"
 }
@@ -89,7 +90,7 @@ ansible::lint() {
 
 args=("$@")
 
-if [ "$0" = "$BASH_SOURCE" ] ; then
+if [ "$0" = "${BASH_SOURCE[*]}" ] ; then
   >&2 echo -E "\nRunning Ansible Lint...\n"
   ansible::lint "${args[@]}"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,5 +19,11 @@ fi
 
 >&2 echo
 >&2 echo "==> Linting ${ACTION_PLAYBOOK_PATH}…"
-ansible-lint "${ACTION_PLAYBOOK_PATH}"
+
+if [ -d "${ACTION_PLAYBOOK_PATH}" ]; then
+  ansible-lint `find "${ACTION_PLAYBOOK_PATH}" -type f -name playbook.yml`
+else
+  ansible-lint "${ACTION_PLAYBOOK_PATH}"
+fi
+
 >&2 echo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,7 @@ parse_args() {
 
 override_python_packages() {
   [[ -n ${OVERRIDE} ]] && pip install "${OVERRIDE}" && pip check
-  echo "Completed installing override dependencies..."
+  >&2 echo "Completed installing override dependencies..."
 }
 
 # Generates client.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,8 +74,12 @@ parse_args() {
   return 0
 }
 
-install_ansible_lint() {
-  pip install ansible-lint=="${VERSION:-${DEFAULT_VERSION}}" || exit 1
+override_python_packages() {
+  echo "Overrides: ${OVERRIDE}"
+  for package in ${OVERRIDE}
+  do
+    pip install "$package" || exit 1
+  done
 }
 
 # Generates client.
@@ -88,7 +92,7 @@ ansible::lint() {
   : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
   pushd "${GITHUB_WORKSPACE}"
 
-  install_ansible_lint
+  override_python_packages
   local opts
   opts=$(parse_args "$@" || exit 1)
   ansible-lint -v --force-color $opts ${TARGETS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,7 +86,6 @@ install_ansible_lint() {
 ansible::lint() {
   : "${TARGETS?No targets to check. Nothing to do.}"
   : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
-  : "${VERSION?No version set. Default: ${DEFAULT_VERSION}}"
   pushd "${GITHUB_WORKSPACE}"
 
   install_ansible_lint "${VERSION:-${DEFAULT_VERSION}}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,9 +3,6 @@
 set -Eeuo pipefail
 set -x
 
-# Setting default ansible-lint version if none is specified.
-DEFAULT_VERSION=4.2.0
-
 # Filter out arguments that are not available to this action
 # args:
 #   $@: Arguments to be filtered

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,14 +10,14 @@ cd "${GITHUB_WORKSPACE}"
 
 ACTION_PLAYBOOK_PATH="${GITHUB_WORKSPACE}/${ACTION_PLAYBOOK_NAME}"
 
-if [ -f "${ACTION_PLAYBOOK_PATH}" ]; then
-  >&2 echo
-  >&2 echo "==> Linting ${ACTION_PLAYBOOK_PATH}…"
-  ansible-lint "${ACTION_PLAYBOOK_PATH}"
-  >&2 echo
-else
+if [ ! -f "${ACTION_PLAYBOOK_PATH}" -a ! -d "${ACTION_PLAYBOOK_PATH}" ]; then
   >&2 echo "==> Can't find '${ACTION_PLAYBOOK_PATH}'.
     Please ensure to set up ACTION_PLAYBOOK_PATH env var
     relative to the root of your project."
   exit 1
 fi
+
+>&2 echo
+>&2 echo "==> Linting ${ACTION_PLAYBOOK_PATH}…"
+ansible-lint "${ACTION_PLAYBOOK_PATH}"
+>&2 echo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,7 +75,7 @@ parse_args() {
 }
 
 install_ansible_lint() {
-  pip install ansible-lint=="$1" || exit 1
+  pip install ansible-lint=="${VERSION:-${DEFAULT_VERSION}}" || exit 1
 }
 
 # Generates client.
@@ -88,7 +88,7 @@ ansible::lint() {
   : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
   pushd "${GITHUB_WORKSPACE}"
 
-  install_ansible_lint "${VERSION:-${DEFAULT_VERSION}}"
+  install_ansible_lint
   local opts
   opts=$(parse_args "$@" || exit 1)
   ansible-lint -v --force-color $opts ${TARGETS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -79,11 +79,11 @@ parse_args() {
 ansible::lint() {
   : "${TARGETS?No targets to check. Nothing to do.}"
   : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
-  pushd ${GITHUB_WORKSPACE}
+  pushd "${GITHUB_WORKSPACE}"
 
   local opts=$(parse_args "$@" || exit 1)
 
-  ansible-lint -v --force-color $opts ${TARGETS}
+  ansible-lint -v --force-color "$opts" "${TARGETS}"
 }
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,7 @@ parse_args() {
         shift
         break
         ;;
-      -*|--*=) # unsupported flags
+      -*) # unsupported flags
         >&2 echo "ERROR: Unsupported flag: '$1'"
         exit 1
         ;;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,9 @@
 set -Eeuo pipefail
 set -x
 
+# Setting default ansible-lint version if none is specified.
+DEFAULT_VERSION=4.2.0
+
 # Filter out arguments that are not available to this action
 # args:
 #   $@: Arguments to be filtered
@@ -71,6 +74,10 @@ parse_args() {
   return 0
 }
 
+install_ansible_lint() {
+  pip install ansible-lint=="$1" || exit 1
+}
+
 # Generates client.
 # args:
 #   $@: additional options
@@ -79,8 +86,10 @@ parse_args() {
 ansible::lint() {
   : "${TARGETS?No targets to check. Nothing to do.}"
   : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
+  : "${VERSION?No version set. Default: ${DEFAULT_VERSION}}"
   pushd "${GITHUB_WORKSPACE}"
 
+  install_ansible_lint "${VERSION:-${DEFAULT_VERSION}}"
   local opts
   opts=$(parse_args "$@" || exit 1)
 
@@ -88,7 +97,11 @@ ansible::lint() {
 }
 
 
+
 args=("$@")
+
+echo "ARGS: $args"
+echo "INPUT $0"
 
 if [ "$0" = "${BASH_SOURCE[*]}" ] ; then
   >&2 echo -E "\nRunning Ansible Lint...\n"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -96,12 +96,7 @@ ansible::lint() {
   ansible-lint -v --force-color "$opts" "${TARGETS}"
 }
 
-
-
 args=("$@")
-
-echo "ARGS: $args"
-echo "INPUT $0"
 
 if [ "$0" = "${BASH_SOURCE[*]}" ] ; then
   >&2 echo -E "\nRunning Ansible Lint...\n"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,6 +73,7 @@ parse_args() {
 
 override_python_packages() {
   [[ -n ${OVERRIDE} ]] && pip install "${OVERRIDE}" && pip check
+  echo "Completed installing override dependencies..."
 }
 
 # Generates client.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,8 +92,13 @@ ansible::lint() {
   install_ansible_lint "${VERSION:-${DEFAULT_VERSION}}"
   local opts
   opts=$(parse_args "$@" || exit 1)
-
-  ansible-lint -v --force-color "$opts" "${TARGETS}"
+  if [[ -z "$opts" ]]; then
+    # If no opts are provided an empty string causes ansible-lint to crash.
+    ansible-lint -v --force-color "${TARGETS}"
+  else
+    ansible-lint -v --force-color "$opts" "${TARGETS}"
+  fi
+  
 }
 
 args=("$@")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,13 +91,7 @@ ansible::lint() {
   install_ansible_lint "${VERSION:-${DEFAULT_VERSION}}"
   local opts
   opts=$(parse_args "$@" || exit 1)
-  if [[ -z "$opts" ]]; then
-    # If no opts are provided an empty string causes ansible-lint to crash.
-    ansible-lint -v --force-color "${TARGETS}"
-  else
-    ansible-lint -v --force-color "$opts" "${TARGETS}"
-  fi
-  
+  ansible-lint -v --force-color $opts ${TARGETS}
 }
 
 args=("$@")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,11 +72,7 @@ parse_args() {
 }
 
 override_python_packages() {
-  echo "Overrides: ${OVERRIDE}"
-  for package in ${OVERRIDE}
-  do
-    pip install "$package" || exit 1
-  done
+  [[ -n ${OVERRIDE} ]] && pip install "${OVERRIDE}"
 }
 
 # Generates client.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ ACTION_PLAYBOOK_PATH="${GITHUB_WORKSPACE}/${ACTION_PLAYBOOK_NAME}"
 
 if [ ! -f "${ACTION_PLAYBOOK_PATH}" -a ! -d "${ACTION_PLAYBOOK_PATH}" ]; then
   >&2 echo "==> Can't find '${ACTION_PLAYBOOK_PATH}'.
-    Please ensure to set up ACTION_PLAYBOOK_PATH env var
+    Please ensure to set up ACTION_PLAYBOOK_NAME env var
     relative to the root of your project."
   exit 1
 fi


### PR DESCRIPTION
Fixes: #16 
- ~Addressed some linting concerns picked up by [shellcheck](https://github.com/koalaman/shellcheck)~
- ~Changed `ADD` to `COPY` as recommended by docker as ADD has additional functionality that may not be intended.~
- Allow new version input so the user can pin their version to align with local development