### PR TITLE
remove quotations from opts variable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,7 +84,7 @@ ansible::lint() {
   local opts
   opts=$(parse_args "$@" || exit 1)
 
-  ansible-lint -v --force-color "$opts" "${TARGETS}"
+  ansible-lint -v --force-color $opts "${TARGETS}"
 }
 
 


### PR DESCRIPTION
Why should we pass some arguments with quotations and other arguments without?

I removed the quotations from ``"$opts"`` to resolve a broken command if the opts variable is empty.

There was a discussion about this in [PR17](https://github.com/ansible/ansible-lint-action/pull/17#discussion_r399293346)

This will probably Resolve Issue #20