### PR TITLE
remove quotation mark from parse_args function

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,7 +88,7 @@ ansible::lint() {
 
   override_python_packages
   local opts
-  opts=$(parse_args "$@" || exit 1)
+  opts=$(parse_args $@ || exit 1)
 
   ansible-lint -v --force-color $opts ${TARGETS}
 }


### PR DESCRIPTION
remove quotation mark from parse_args function
and resolve https://github.com/ansible/ansible-lint-action/issues/22

I tested it [there](https://github.com/roles-ansible/role_ranger/runs/570398160).