### PR TITLE
Install git (used by ansible-lint)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ LABEL "com.github.actions.description"="Run Ansible Lint"
 LABEL "com.github.actions.icon"="activity"
 LABEL "com.github.actions.color"="gray-dark"
 
+# Install git (required by ansible-lint)
+RUN set -ex && apt-get update && apt-get -q install -y -V git && rm -rf /var/lib/apt/lists/*
+
 RUN pip install ansible-lint
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Since ansible-lint 4.2.0 (more specifically https://github.com/ansible/ansible-lint/commit/ad721b6cde91a65e28d1f4fa4052bb721b17ae11 4.1.1a4) it uses `git ls-files` to scan the directory. This is why current action fails (i.e. here: https://github.com/baschny/ansible-color-prompt/pull/1/checks?check_run_id=573823435).

Simply install git in the docker container to make it work. The installation of the package is done this way (deleting the apt "lists" afterwards) to generate the smallest possible docker layer.