### PR TITLE
Enable recursive glob patterns

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,7 +90,10 @@ ansible::lint() {
   local opts
   opts=$(parse_args $@ || exit 1)
 
+  # Enable recursive glob patterns, such as '**/*.yml'.
+  shopt -s globstar
   ansible-lint -v --force-color $opts ${TARGETS}
+  shopt -u globstar
 }
 
 


### PR DESCRIPTION
First of all, thanks for the action.

This PR lets it take a `**/*.yml` pattern as a `target` argument. Previously, it would silently fail when given such a pattern:
```
+ ansible-lint -v --force-color '**/*.yml'
WARNING: Couldn't open **/*.yml - No such file or directory
```