### PR TITLE
Fix "unbound variable" bash error when OVERRIDE is not defined

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,7 @@ parse_args() {
 }
 
 override_python_packages() {
-  [[ -n "${OVERRIDE}" ]] && pip install ${OVERRIDE} && pip check
+  [[ -n "${OVERRIDE-}" ]] && pip install ${OVERRIDE} && pip check
   >&2 echo "Completed installing override dependencies..."
 }
 


### PR DESCRIPTION
By default, bash renders undefined variables as empty strings,
but entrypoint.sh does a "set -u" - which causes bash to report the
"unbound variable" error instead. That's incompatible with the way
the script checks if OVERRIDE is defined, by checking if its length is 0.

We now check the variable by doing "${OVERRIDE-}", where the "-" forces
the variable to be rendered as the empty string if not defined.