### PR TITLE
Fix issue with ansible 2.9.x and upgrade to python:3.9slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL "com.github.actions.color"="gray-dark"
 # Install git (required by ansible-lint)
 RUN set -ex && apt-get update && apt-get -q install -y -V git && rm -rf /var/lib/apt/lists/*
 
-RUN pip install ansible-lint
+RUN pip install ansible==2.9.6 ansible-lint
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 LABEL "maintainer"="Ansible by Red Hat <info@ansible.com>"
 LABEL "repository"="https://github.com/ansible/ansible-lint-action"
@@ -11,8 +11,6 @@ LABEL "com.github.actions.color"="gray-dark"
 
 # Install git (required by ansible-lint)
 RUN set -ex && apt-get update && apt-get -q install -y -V git && rm -rf /var/lib/apt/lists/*
-
-RUN pip install ansible==2.9.6 ansible-lint
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,14 +71,14 @@ parse_args() {
   return 0
 }
 
-override_python_packages() {
+install_ansible_packages() {
   if [[ "$OVERRIDE" == *"ansible-lint"* ]]; then
     echo "ansible-lint specified."
   else
     OVERRIDE="$OVERRIDE ansible-lint"
   fi
   pip install ${OVERRIDE} && pip check
-  >&2 echo "Completed installing override dependencies..."
+  >&2 echo "Completed installing ansible dependencies including overrides..."
 }
 
 # Generates client.
@@ -91,7 +91,7 @@ ansible::lint() {
   : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
   pushd "${GITHUB_WORKSPACE}"
 
-  override_python_packages
+  install_ansible_packages
   local opts
   opts=$(parse_args $@ || exit 1)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,9 +72,12 @@ parse_args() {
 }
 
 override_python_packages() {
-  >&2 echo "${OVERRIDE}"
-  >&2 echo "${OVERRIDE-}"
-  [[ -n "${OVERRIDE-}" ]] && pip install ${OVERRIDE} && pip check
+  if [[ "$OVERRIDE" == *"ansible-lint"* ]]; then
+    echo "ansible-lint specified."
+  else
+    OVERRIDE="$OVERRIDE ansible-lint"
+  fi
+  pip install ${OVERRIDE} && pip check
   >&2 echo "Completed installing override dependencies..."
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,6 +72,8 @@ parse_args() {
 }
 
 override_python_packages() {
+  >&2 echo "${OVERRIDE}"
+  >&2 echo "${OVERRIDE-}"
   [[ -n "${OVERRIDE-}" ]] && pip install ${OVERRIDE} && pip check
   >&2 echo "Completed installing override dependencies..."
 }


### PR DESCRIPTION
This patch fixes #41 and offers a couple performance improvements:

- If using what would previously have been an 'override' version, the default version isn't installed and uninstalled, saving 1 minute or more.
- Python has been bumped to 3.9, which offers minor performance benefits.

This has been tested with:
- No overrides specified - installs latest ansible-lint (and latest ansible via dependency)
- Ansible version overridden - installs override ansible and latest ansible-lint
- Ansible-lint version overridden - installs override ansible-lint (and latest ansible via dependency)
- Both overridden - installs override ansible-lint and ansible