### PR TITLE
Get TARGETS and OVERRIDE from input environment variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,8 +43,3 @@ inputs:
 runs:
   using: docker
   image: Dockerfile
-  args:
-  - ${{ inputs.args }}
-  env:
-    TARGETS: ${{ inputs.targets }}
-    OVERRIDE: ${{ inputs.override-deps }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,7 @@ parse_args() {
 }
 
 override_python_packages() {
-  [[ -n "${OVERRIDE-}" ]] && pip install ${OVERRIDE} && pip check
+  [[ -n "${INPUT_OVERRIDE_DEPS-}" ]] && pip install ${INPUT_OVERRIDE_DEPS} && pip check
   >&2 echo "Completed installing override dependencies..."
 }
 
@@ -80,9 +80,8 @@ override_python_packages() {
 # args:
 #   $@: additional options
 # env:
-#   [required] TARGETS : Files or directories (i.e., playbooks, tasks, handlers etc..) to be linted
+#   INPUT_TARGETS : Files or directories (i.e., playbooks, tasks, handlers etc..) to be linted
 ansible::lint() {
-  : "${TARGETS?No targets to check. Nothing to do.}"
   : "${GITHUB_WORKSPACE?GITHUB_WORKSPACE has to be set. Did you use the actions/checkout action?}"
   pushd "${GITHUB_WORKSPACE}"
 
@@ -92,12 +91,15 @@ ansible::lint() {
 
   # Enable recursive glob patterns, such as '**/*.yml'.
   shopt -s globstar
-  ansible-lint -v --force-color $opts ${TARGETS}
+  ansible-lint -v --force-color $opts ${INPUT_TARGETS=}
   shopt -u globstar
 }
 
-
-args=("$@")
+if [ -n "${INPUT_ARGS-}" ]; then
+    IFS=' ' read -r -a args <<< "$INPUT_ARGS"
+else
+    args=()
+fi
 
 if [ "$0" = "${BASH_SOURCE[*]}" ] ; then
   >&2 echo -E "\nRunning Ansible Lint...\n"


### PR DESCRIPTION
This makes the docker image itself runnable as a github action, in
contrast with having to use the github repository as the action, and
having to wait for the image to be built in the context of the action.

The main difference is that we don't have actions.yml to move the
arguments to environment variables, so we are now using them
directly  via the INPUT_* variables.

This also removes the TARGETS (now INPUT_TARGETS) check,
my understanding is that it was never failing because the variable
always exists, it's just empty when the caller doesn't define a value.