### PR TITLE
fix: typo on args help

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
         -t TAGS               only check rules whose id/tags match these values
         -x SKIP_LIST          only check rules whose id/tags do not match these
                               values
-        --nocolor             disable colored output
+        --no-color            disable colored output
         --exclude=EXCLUDE_PATHS
                               path to directories or files to skip. This option is
                               repeatable.


### PR DESCRIPTION
Compared with argument on entrypoint.sh

https://github.com/ansible/ansible-lint-action/blob/c37fb7b4bda2c8cb18f4942716bae9f11b0dc9bc/entrypoint.sh#L46