### PR TITLE
add docker:// to image name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: "."
 runs:
   using: docker
-  image: quay.io/ansible/creator-ee:v0.3.1
+  image: docker://quay.io/ansible/creator-ee:v0.3.1
   entrypoint: /usr/local/bin/ansible-lint
   env:
     # These tell ansible-lint to use github compatible annotation format:


### PR DESCRIPTION
This PR
- adds the `docker://` prefix to the image name

Closes #78 

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>