### PR TITLE
Add GitHub workflow to synchronize Docker images

### DIFF
--- a/.github/workflows/mirror-docker.yml
+++ b/.github/workflows/mirror-docker.yml
@@ -1,0 +1,47 @@
+---
+name: Periodic Docker image sync to docker.io and ghcr.io
+
+on:
+  workflow_dispatch:
+  # schedule:
+    # At the start of every hour
+    # - cron: '0 * * * *'
+
+jobs:
+  mirror-images:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set image variables
+        run: |
+          echo "QUAY_IMAGE_NAME=$(grep -Po '(?<=docker://quay.io/).*(?=:.*$)' action.yml)" >> $GITHUB_ENV
+          echo "QUAY_IMAGE_TAG=$(grep -Po "(?<=docker://quay.io/$QUAY_IMAGE_NAME:).*$" action.yml)" >> $GITHUB_ENV
+
+      - name: Fetch quay.io image
+        run: docker pull "${QUAY_IMAGE_NAME}:${QUAY_IMAGE_TAG}"
+
+      # To authenticate against Docker Hub it's strongly recommended
+      # to create a personal access token as an alternative to your password
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Tag and push image to Docker Hub
+        run: |
+          docker tag "${QUAY_IMAGE_NAME}:${QUAY_IMAGE_TAG}" "docker.io/${QUAY_IMAGE_NAME}:${QUAY_IMAGE_TAG}"
+          docker push "docker.io/${QUAY_IMAGE_NAME}:${QUAY_IMAGE_TAG}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and push image to GitHub Container Registry
+        run: |
+          docker tag "${QUAY_IMAGE_NAME}:${QUAY_IMAGE_TAG}" "ghcr.io/${QUAY_IMAGE_NAME}:${QUAY_IMAGE_TAG}"
+          docker push "ghcr.io/${QUAY_IMAGE_NAME}:${QUAY_IMAGE_TAG}"


### PR DESCRIPTION
Hi :wave: 

This PR adds a GitHub workflow to synchronize the `ansible/creator-ee` Docker image from quay.io to ghcr.io and docker.io, as discussed in #67.

I'm creating it as a draft because I have some questions:

1. If the idea is to speed up the ansible-lint-action, I think that this PR should also change the `image:` setting of `action.yml` to use the GitHub container registry. But if we do this, I won't be able to `grep` the current values of image name and image tag relative to the quay.io image (lines 18 and 19 of the workflow). If we add the values as `env:` values, then the maintainers will have to update that value manually whenever they want to change the image tag (this is already done because it needs to be updated in `action.yml` anyways). I'm not comfortable in bringing additional work to maintainers, therefore I'm bringing this point for discussion here.
2. The image tags are wrong in this draft, because I need to confirm with you what are the org names on Docker Hub so I can adjust them properly. The ghcr.io image will be `ansible-community/creator-ee:<some_tag>`, is that ok for you?

Regards,
channelbeta